### PR TITLE
Log send mail error

### DIFF
--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -63,7 +63,7 @@ Mailer.prototype.sendEmail = async function (type, to, data, i18n) {
         throw new Error('Email transport not defined.');
     }
   } catch (error) {
-    logger.error('Could not not send e-mail, please review settings.');
+    logger.error('Mail sending error.', error);
     throw new Error(`Error sending e-mail: ${error.message}.`);
   }
 };


### PR DESCRIPTION
Turns out https://github.com/mapascoletivos/api/issues/50 didn't logged "send mail" errors properly. This should fix it.